### PR TITLE
CD-3129 Added support to select organization option for dedicated instances

### DIFF
--- a/common/src/main/java/org/sonarlint/intellij/common/util/SonarLintUtils.java
+++ b/common/src/main/java/org/sonarlint/intellij/common/util/SonarLintUtils.java
@@ -58,8 +58,8 @@ import org.jetbrains.jps.model.java.JavaSourceRootProperties;
 
 public class SonarLintUtils {
 
+  public static final String CODESCAN_DOMAIN = "codescan.io";
   private static final Logger LOG = Logger.getInstance(SonarLintUtils.class);
-  private static final String[] SONARCLOUD_ALIAS = {"https://app.codescan.io", "https://app-eu.codescan.io"};
 
   private SonarLintUtils() {
     // Utility class
@@ -96,7 +96,7 @@ public class SonarLintUtils {
   }
 
   public static boolean isCodeScanCloudAlias(@Nullable String url) {
-    return Arrays.asList(SONARCLOUD_ALIAS).contains(url);
+    return url != null && url.contains(CODESCAN_DOMAIN);
   }
 
   public static boolean isEmpty(@Nullable String str) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=6.1.3
+version=6.1.4
 org.gradle.jvmargs=-XX:MaxPermSize=256M
 sonarlintCoreVersion=7.0.0-CODESCAN
 intellijBuildVersion=IC-2020.1.3

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/AuthStep.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/AuthStep.java
@@ -145,7 +145,7 @@ public class AuthStep extends AbstractWizardStepEx {
   @Nullable
   @Override
   public Object getNextStepId() {
-    if (model.getServerType() == WizardModel.ServerType.SONARCLOUD || CodescanCloudConstants.CODESCAN_EU_URL.equals(model.getServerUrl())) {
+    if (model.getServerType() == WizardModel.ServerType.SONARCLOUD) {
       return OrganizationStep.class;
     }
     if (model.isNotificationsSupported()) {

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/CodescanCloudConstants.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/CodescanCloudConstants.java
@@ -20,10 +20,8 @@
 package org.sonarlint.intellij.config.global.wizard;
 
 public class CodescanCloudConstants {
-  private CodescanCloudConstants() {
-  }
-
-  public static final String CODESCAN_US_URL = "https://app.codescan.io";
-  public static final String CODESCAN_EU_URL = "https://app-eu.codescan.io";
-  public static final String CODESCAN_EU_DOMAIN = "app-eu.codescan.io";
+    public static final String CODESCAN_US_URL = "https://app.codescan.io";
+    public static final String CODESCAN_DOMAIN = "codescan.io";
+    private CodescanCloudConstants() {
+    }
 }

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/ConfirmStep.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/ConfirmStep.java
@@ -75,7 +75,7 @@ public class ConfirmStep extends AbstractWizardStepEx {
     if (model.isNotificationsSupported()) {
       return NotificationsStep.class;
     }
-    if (model.getServerType() == WizardModel.ServerType.SONARCLOUD || CodescanCloudConstants.CODESCAN_EU_URL.equals(model.getServerUrl())) {
+    if (model.getServerType() == WizardModel.ServerType.SONARCLOUD) {
       return OrganizationStep.class;
     }
     return AuthStep.class;

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/NotificationsStep.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/NotificationsStep.java
@@ -84,7 +84,7 @@ public class NotificationsStep extends AbstractWizardStepEx {
     if (onlyEditNotifications) {
       return null;
     }
-    if (model.getServerType() == WizardModel.ServerType.SONARCLOUD || CodescanCloudConstants.CODESCAN_EU_URL.equals(model.getServerUrl())) {
+    if (model.getServerType() == WizardModel.ServerType.SONARCLOUD) {
       return OrganizationStep.class;
     } else {
       return AuthStep.class;

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/ServerStep.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/ServerStep.java
@@ -120,7 +120,8 @@ public class ServerStep extends AbstractWizardStepEx {
     Icon sqIcon = SonarLintIcons.ICON_CODESCAN;
     Icon clIcon = SonarLintIcons.ICON_CODESCAN;
 
-    if ((model.getServerType() == WizardModel.ServerType.SONARCLOUD && !CodescanCloudConstants.CODESCAN_EU_URL.equals(model.getServerUrl())) || model.getServerType() == null) {
+    if ((model.getServerType() == WizardModel.ServerType.SONARCLOUD &&
+            CodescanCloudConstants.CODESCAN_US_URL.equals(model.getServerUrl())) || model.getServerType() == null) {
       radioCodeScanCloud.setSelected(true);
       if (editing) {
         sqIcon = SonarLintIcons.toDisabled(sqIcon);
@@ -211,12 +212,12 @@ public class ServerStep extends AbstractWizardStepEx {
       model.setServerType(WizardModel.ServerType.SONARCLOUD);
       model.setServerUrl(CodescanCloudConstants.CODESCAN_US_URL);
     } else {
-      model.setServerType(WizardModel.ServerType.SONARQUBE);
       String serverUrl = urlText.getText().trim();
-      if (serverUrl.contains(CodescanCloudConstants.CODESCAN_EU_DOMAIN)) {
-        model.setServerUrl(CodescanCloudConstants.CODESCAN_EU_URL);
+      model.setServerUrl(serverUrl);
+      if (serverUrl.contains(CodescanCloudConstants.CODESCAN_DOMAIN)) {
+        model.setServerType(WizardModel.ServerType.SONARCLOUD);
       } else {
-        model.setServerUrl(serverUrl);
+        model.setServerType(WizardModel.ServerType.SONARQUBE);
       }
     }
     model.setName(nameField.getText().trim());

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/WizardModel.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/WizardModel.java
@@ -35,7 +35,6 @@ import org.sonarlint.intellij.tasks.GetOrganizationsTask;
 import org.sonarsource.sonarlint.core.serverapi.organization.ServerOrganization;
 
 public class WizardModel {
-  private static final String SONARCLOUD_URL = "https://app.codescan.io";
   private ServerType serverType;
   private String serverUrl;
   private String token;
@@ -61,13 +60,10 @@ public class WizardModel {
   public WizardModel(ServerConnection connectionToEdit) {
     if (SonarLintUtils.isCodeScanCloudAlias(connectionToEdit.getHostUrl())) {
       serverType = ServerType.SONARCLOUD;
-      if (CodescanCloudConstants.CODESCAN_EU_URL.contains(connectionToEdit.getHostUrl())) {
-        serverUrl = connectionToEdit.getHostUrl();
-      }
     } else {
       serverType = ServerType.SONARQUBE;
-      serverUrl = connectionToEdit.getHostUrl();
     }
+    serverUrl = connectionToEdit.getHostUrl();
     this.proxyEnabled = connectionToEdit.enableProxy();
     this.token = connectionToEdit.getToken();
     this.login = connectionToEdit.getLogin();
@@ -245,15 +241,7 @@ public class WizardModel {
       .setOrganizationKey(organizationKey)
       .setEnableProxy(proxyEnabled)
       .setName(name);
-
-    if (serverType == ServerType.SONARCLOUD) {
-      builder.setHostUrl(SONARCLOUD_URL);
-      if (serverUrl != null && CodescanCloudConstants.CODESCAN_EU_URL.equals(serverUrl)) {
-        builder.setHostUrl(CodescanCloudConstants.CODESCAN_EU_URL);
-      }
-    } else {
-      builder.setHostUrl(serverUrl);
-    }
+    builder.setHostUrl(serverUrl);
 
     if (token != null) {
       builder.setToken(token)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,6 +52,7 @@
 
     <change-notes><![CDATA[
       <ul>
+        <li>6.1.4 - Added support for using the plugin with CodeScan dedicated instances.</li>
         <li>6.1.3 - Fix Edit Connection Behavior for CodeScanCloud EU users.</li>
         <li>6.1.2 - Added support of using CodeScan Cloud Europe servers: app-eu.codescan.io.</li>
         <li>6.1.1 - Enhanced runtime error logging of plugin: added option to send information about occuring exceptions to CodeScan dev team.</li>


### PR DESCRIPTION
Selecting the organization option is only available for codescan US and EU instances. When the user tries to connect to any of the dedicated instances, its treated as a sonarqube instance(without org support) resulting in not able to fetch projects from that instance. 

With this fix all the instance containing **codescan.io**  in domain will be treated as a codescan cloud instance and organization option will be available for them. 